### PR TITLE
tolerate whitespace before json parameter map

### DIFF
--- a/jprc2_request.go
+++ b/jprc2_request.go
@@ -41,7 +41,7 @@ func (r *jsonRPCRequest) setMethodAndParams(args []string) error {
 			// or an 'object' in javascript terms
 			r.Params = kvPairsToMap(args[1:])
 
-		} else if len(args[1]) > 1 && args[1][0] == '{' {
+		} else if len(args[1]) > 1 && strings.TrimLeft(args[1], " \n\t")[0] == '{' {
 			var obj, err = stringToJSObject(args[1])
 			if err != nil {
 				return err


### PR DESCRIPTION
a call like ` chello ... METHOD ' {"p1":"x","p2":"y"} ' `
will not take parameters from the given map and instead
interpret last argument as a single string parameter.
with this change leading whitespace will be ignored
hence detecting the above as a parameter map.